### PR TITLE
feat(backup/source/mongo): Add optional TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,49 @@ AuthenticationDatabase: "test" # default is admin
 Database: "test"
 ```
 
+Dump single db with TLS
+
+The CA bundle is read from system trust store paths
+(`/etc/ssl/certs/ca-certificates.crt`, `/etc/pki/tls/certs/ca-bundle.crt`,
+`/etc/ssl/cert.pem`). On most Linux distributions and in Kubernetes pods
+where the cluster CA is mounted at these paths, no further configuration
+is needed.
+
+```yaml
+Host: "127.0.0.1"
+Port: "27017"
+User: "root"
+Password: "root"
+Database: "test"
+TLS: true
+```
+
+Dump single db with TLS and explicit CA file
+
+Use `TLSCAFile` if your CA is at a non-standard path.
+
+```yaml
+Host: "127.0.0.1"
+Port: "27017"
+User: "root"
+Password: "root"
+Database: "test"
+TLS: true
+TLSCAFile: "/etc/ssl/custom/ca.crt"
+```
+
+Dump single db with TLS and skip hostname verification
+
+```yaml
+Host: "127.0.0.1"
+Port: "27017"
+User: "root"
+Password: "root"
+Database: "test"
+TLS: true
+TLSAllowInvalidHostnames: true
+```
+
 #### Example BackupSourceKubernetesTLSSecret Block
 
 Backup all TLS secrets

--- a/backup/source/mongo/mongo.go
+++ b/backup/source/mongo/mongo.go
@@ -9,12 +9,15 @@ import (
 )
 
 type MongoSource struct {
-	Host                   string `yaml:"Host" json:"Host,omitempty"`
-	Port                   string `yaml:"Port" json:"Port,omitempty"`
-	User                   string `yaml:"User" json:"User,omitempty"`
-	Password               string `yaml:"Password" json:"Password,omitempty"`
-	Database               string `yaml:"Database" json:"Database,omitempty"`
-	AuthenticationDatabase string `yaml:"AuthenticationDatabase" json:"AuthenticationDatabase,omitempty"`
+	Host                     string `yaml:"Host" json:"Host,omitempty"`
+	Port                     string `yaml:"Port" json:"Port,omitempty"`
+	User                     string `yaml:"User" json:"User,omitempty"`
+	Password                 string `yaml:"Password" json:"Password,omitempty"`
+	Database                 string `yaml:"Database" json:"Database,omitempty"`
+	AuthenticationDatabase   string `yaml:"AuthenticationDatabase" json:"AuthenticationDatabase,omitempty"`
+	TLS                      bool   `yaml:"TLS" json:"TLS,omitempty"`
+	TLSCAFile                string `yaml:"TLSCAFile" json:"TLSCAFile,omitempty"`
+	TLSAllowInvalidHostnames bool   `yaml:"TLSAllowInvalidHostnames" json:"TLSAllowInvalidHostnames,omitempty"`
 }
 
 func (s MongoSource) Validate() error {
@@ -59,6 +62,15 @@ func (s MongoSource) Backup() (backup_output.BackupOutput, error) {
 			args,
 			"--db", s.Database,
 		)
+	}
+	if s.TLS {
+		args = append(args, "--tls")
+		if s.TLSCAFile != "" {
+			args = append(args, "--tlsCAFile", s.TLSCAFile)
+		}
+		if s.TLSAllowInvalidHostnames {
+			args = append(args, "--tlsAllowInvalidHostnames")
+		}
 	}
 
 	tmpBo, err := backup_process_utils.BackupProcessExecToFile(


### PR DESCRIPTION
Adds three optional fields to MongoSource for connecting to TLS-enabled.

MongoDB deployments:

- TLS                       (bool)
- TLSCAFile                 (string)
- TLSAllowInvalidHostnames  (bool)

All three are optional; existing configs continue to work unchanged.

Design notes:

- TLSCAFile is intentionally optional. mongodump on Linux falls back to standard CA paths (/etc/ssl/certs/ca-certificates.crt, /etc/pki/tls/certs/ca-bundle.crt, /etc/ssl/cert.pem). In Kubernetes setups where the cluster CA is injected into pods at these paths (e.g., via a Kyverno mutation policy + trust-manager), users only need TLS: true.

- TLSAllowInvalidHostnames is included as an escape hatch for deployments where cert SANs don't fully match (e.g., reaching a ReplicaSet through a non-SAN service name).

README updated with three examples covering the common cases.