### PR TITLE
feat(backup/source/mongo): Add optional SSL/TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,37 @@ AuthenticationDatabase: "test" # default is admin
 Database: "test"
 ```
 
+Dump single db with SSL/TLS
+
+The CA bundle is read from system trust store paths
+(`/etc/ssl/certs/ca-certificates.crt`, `/etc/pki/tls/certs/ca-bundle.crt`,
+`/etc/ssl/cert.pem`). On most Linux distributions and in Kubernetes pods
+where the cluster CA is mounted at these paths, no further configuration
+is needed.
+
+```yaml
+Host: "127.0.0.1"
+Port: "27017"
+User: "root"
+Password: "root"
+Database: "test"
+SSL: true
+```
+
+Dump single db with SSL/TLS and explicit CA file
+
+Use `SSLCAFile` if your CA is at a non-standard path.
+
+```yaml
+Host: "127.0.0.1"
+Port: "27017"
+User: "root"
+Password: "root"
+Database: "test"
+SSL: true
+SSLCAFile: "/etc/ssl/custom/ca.crt"
+```
+
 #### Example BackupSourceKubernetesTLSSecret Block
 
 Backup all TLS secrets

--- a/backup/source/mongo/mongo.go
+++ b/backup/source/mongo/mongo.go
@@ -15,6 +15,8 @@ type MongoSource struct {
 	Password               string `yaml:"Password" json:"Password,omitempty"`
 	Database               string `yaml:"Database" json:"Database,omitempty"`
 	AuthenticationDatabase string `yaml:"AuthenticationDatabase" json:"AuthenticationDatabase,omitempty"`
+	SSL                    bool   `yaml:"SSL" json:"SSL,omitempty"`
+	SSLCAFile              string `yaml:"SSLCAFile" json:"SSLCAFile,omitempty"`
 }
 
 func (s MongoSource) Validate() error {
@@ -59,6 +61,12 @@ func (s MongoSource) Backup() (backup_output.BackupOutput, error) {
 			args,
 			"--db", s.Database,
 		)
+	}
+	if s.SSL {
+		args = append(args, "--ssl")
+		if s.SSLCAFile != "" {
+			args = append(args, "--sslCAFile", s.SSLCAFile)
+		}
 	}
 
 	tmpBo, err := backup_process_utils.BackupProcessExecToFile(


### PR DESCRIPTION
I tested this end-to-end in the PSS DEV cluster against a real TLS-only MongoDB ReplicaSet. Found and fixed a few things:

1. YAML parsing flows transparently through struct tags, same pattern as `SSLMode` in Postgres (Ondrej's commit 76e2240). No central registry to update - the `yaml:`/`json:` tags on `MongoSource` are sufficient.

2. My original version used `--tls`/`--tlsCAFile` flags, but MongoDB Database Tools (even the current 100.16.0) still use `--ssl`/`--sslCAFile`. The `--tls` flag doesn't exist on mongodump at all. Renamed the struct fields to `SSL`, `SSLCAFile` — matches the CLI flags and the project's existing `SSLMode` convention from Postgres.

3. Dropped `TLSAllowInvalidHostnames`. mongodump only has `--tlsInsecure`, which bypasses both CA validation *and* hostname validation - more than we want. If someone needs it later, easy follow-up.

In-pod test (mongodb-svc.mongodb.svc, TLS-only, real ReplicaSet):

/tmp/tergum backup -c /tmp/config.yml
→ OK, 4.2K archive, cron.* collections dumped